### PR TITLE
partition_type: Allow GUID as partition type

### DIFF
--- a/gpt_reader.py
+++ b/gpt_reader.py
@@ -50,7 +50,7 @@ def main():
         os.makedirs(args.output_dir)
 
     for partition in reader.partition_table.valid_entries():
-        print('{} {} {} {}'.format(
+        print('guid/type={} first-block={} size={} name={}'.format(
             partition.partition_type, partition.first_block, partition.length, partition.name))
 
         if args.burst:

--- a/partition_table_entry.py
+++ b/partition_table_entry.py
@@ -14,8 +14,10 @@ class PartitionTableEntry(object):
         self._last_lba = last_lba
 
         self._name = name.decode('utf-16').rstrip('\0')
-
-        self._part_type = PartitionTypes(self._type_uuid)
+        try:
+            self._part_type = PartitionTypes(self._type_uuid)
+        except ValueError:
+            self._part_type = self._type_uuid
 
     def __repr__(self):
         if self._part_type == PartitionTypes.Unused:


### PR DESCRIPTION
Since PartitionType enumerator class is currently limited in scope and GPT partition can come with any GUID, allow partition type processing of unknown types. Basically GUID is then
used as a type. Also includes a minor formatting improvement.

Signed-off-by: Faheem Sheikh <fahim.sheikh@gmail.com>

PS: @pvachon Thanks for a version which actually works with sector size of 4096. I tried other GPT parsers and most just supported 512. :+1: 